### PR TITLE
kern: Initial work for pager interface.

### DIFF
--- a/kern/perf.h
+++ b/kern/perf.h
@@ -26,6 +26,22 @@ NUXPERF(pmachina_ipc_recv_invalidname);
 NUXPERF(pmachina_ipc_recv_dequeuefailed);
 NUXPERF(pmachina_ipc_recv_success);
 
+NUXPERF(pmachina_vmobj_faults);
+NUXPERF(pmachina_vmobj_fault_empty);
+NUXPERF(pmachina_vmobj_fault_empty_shdw);
+NUXPERF(pmachina_vmobj_fault_ro);
+NUXPERF(pmachina_vmobj_fault_ro_unlock);
+NUXPERF(pmachina_vmobj_fault_ro_shdw);
+NUXPERF(pmachina_vmobj_fault_ro_push);
+NUXPERF(pmachina_vmobj_fault_ro_unshare);
+NUXPERF(pmachina_vmobj_fault_priv);
+NUXPERF(pmachina_vmobj_fault_priv_unlock);
+
+NUXPERF(pmachina_vmobj_pgreq_empty);
+NUXPERF(pmachina_vmobj_pgreq_pgin);
+NUXPERF(pmachina_vmobj_pgreq_pgout);
+NUXPERF(pmachina_vmobj_pgreq_paged);
+
 NUXPERF(pmachina_cacheobj_addmapping);
 NUXPERF(pmachina_cacheobj_updatemapping);
 NUXPERF(pmachina_cacheobj_delmapping);

--- a/kern/task.c
+++ b/kern/task.c
@@ -168,7 +168,7 @@ task_vm_allocate (struct task *t, vaddr_t * addr, size_t size, bool anywhere)
 
   TASK_PRINT ("TASK: allocating task %p size %lx anywhere %d\n", t, size,
 	  anywhere);
-  ref = vmobj_new (true, size);
+  ref = vmobj_new (NULL, size);
 
   return task_vm_map (t, addr, size, 0, anywhere, ref, 0, 0,
 		      MCN_VMPROT_DEFAULT, MCN_VMPROT_ALL,
@@ -294,7 +294,7 @@ task_bootstrap (struct taskref *taskref)
   thread_resume(threadref_unsafe_get(&threadref));
   threadref_consume(&threadref);
 
-  struct vmobjref ref = vmobj_new (true, 3 * 4096);
+  struct vmobjref ref = vmobj_new (NULL, 3 * 4096);
   //  struct vmobjref ref2 = vmobjref_clone(&ref);
   vmmap_map (&t->vmmap, 0x1000, ref, 0, 4 * 4096, MCN_VMPROT_ALL,
 	     MCN_VMPROT_ALL);


### PR DESCRIPTION
This commit moves the zero-page filling part of the vmobj fault to a pager request interface, and adds a trivial default pager (no page-out and page-in).

A change here is that we're removing an optimization: in previous code when we were requesting a page from the pager and the mapping was roshared, but we were operating on a write fault, we would first get the page and then push, thus saving a page fault.

In the spirit of correct-first optimize-later, for now this optimization has been removed, at least until we have a fully working pager interface.